### PR TITLE
support bundle install with native dependencies by installing ruby-devel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN yum install -y \
     openssh-server \
     openssh-client \
     ruby \
+    ruby-devel \
     rubygem-bundler \
     git
 


### PR DESCRIPTION
This should allow to run `bundle install`, `bundle exec...` and other ruby things when native extensions are involved.
